### PR TITLE
Change to Using Different PubNub Instance Across Scenes

### DIFF
--- a/Assets/SuperMultiplayerShooter/Scripts/ChatSystem.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/ChatSystem.cs
@@ -45,7 +45,7 @@ namespace Visyde
         void Start()
         {
             //Initializes the PubNub Connection.
-            pubnub = PNManager.pubnubInstance;
+            pubnub = PNManager.pubnubInstance.InitializePubNub();
 
             //Add Listeners
             pubnub.AddListener(listener);

--- a/Assets/SuperMultiplayerShooter/Scripts/GameManager.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/GameManager.cs
@@ -156,7 +156,7 @@ namespace Visyde
             Screen.sleepTimeout = SleepTimeout.NeverSleep;
 
             //  Initialize PubNub and subscribe to the appropriate channels
-            pubnub = PNManager.pubnubInstance;
+            pubnub = PNManager.pubnubInstance.InitializePubNub();
             List<string> channels = new List<string>();
             channels.Add(PubNubUtilities.itemChannel);
             //  Every player will send their updates on a unique channel, so subscribe to those

--- a/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
@@ -86,7 +86,7 @@ namespace Visyde
         void Start()
         {
             //Initializes the PubNub Connection.
-            pubnub = PNManager.pubnubInstance;
+            pubnub = PNManager.pubnubInstance.InitializePubNub();
 
             //Add Listeners
             pubnub.AddListener(listener);
@@ -207,7 +207,7 @@ namespace Visyde
                 //When user joins, check their UUID in cached players to determine if they are a new player.                 
                 if (!PNManager.pubnubInstance.CachedPlayers.ContainsKey(result.Uuid))
                 {
-                    GetUserMetadata(result.Uuid);
+                    PNManager.pubnubInstance.GetUserMetadata(result.Uuid);
                 }
             }
 
@@ -313,61 +313,6 @@ namespace Visyde
             //Clear out the cached players when changing scenes. The list needs to be updated when returning to the scene in case
             //there are new players.
             PNManager.pubnubInstance.CachedPlayers.Clear();
-        }
-
-        /// <summary>
-        /// Returns the user's nickname. If it is not cached, it will obtain this information.
-        /// </summary>
-        /// <returns></returns>
-        private string GetUserNickname()
-        {
-            string nickname = "";
-            if(PNManager.pubnubInstance.CachedPlayers.ContainsKey(pubnub.GetCurrentUserId())
-                && !string.IsNullOrWhiteSpace(PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name))
-            {
-                nickname = PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name;
-            }
-
-            else
-            {
-                //Obtain the user metadata. IF the nickname cannot be found, set to be the first 6 characters of the UserId.
-                GetUserMetadata(pubnub.GetCurrentUserId());
-                nickname = !string.IsNullOrWhiteSpace(PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name) ? PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name : pubnub.GetCurrentUserId();
-            }
-
-            return nickname;
-        }
-
-        /// <summary>
-        /// Get the User Metadata given the UserId.
-        /// </summary>
-        /// <param name="Uuid">UserId of the Player</param>
-        private async void GetUserMetadata(string Uuid)
-        {
-            //If they do not exist, pull in their metadata (since they would have already registered when first opening app), and add to cached players.                
-            // Get Metadata for a specific UUID
-            PNResult<PNGetUuidMetadataResult> getUuidMetadataResponse = await pubnub.GetUuidMetadata()
-                .Uuid(Uuid)
-                .ExecuteAsync();
-            PNGetUuidMetadataResult getUuidMetadataResult = getUuidMetadataResponse.Result;
-            PNStatus status = getUuidMetadataResponse.Status;
-            if (!status.Error && getUuidMetadataResult != null)
-            {
-                UserMetadata meta = new UserMetadata
-                {
-                    Uuid = getUuidMetadataResult.Uuid,
-                    Name = getUuidMetadataResult.Name,
-                    Email = getUuidMetadataResult.Email,
-                    ExternalId = getUuidMetadataResult.ExternalId,
-                    ProfileUrl = getUuidMetadataResult.ProfileUrl,
-                    Custom = getUuidMetadataResult.Custom,
-                    Updated = getUuidMetadataResult.Updated
-                };
-                if (!PNManager.pubnubInstance.CachedPlayers.ContainsKey(getUuidMetadataResult.Uuid))
-                {
-                    PNManager.pubnubInstance.CachedPlayers.Add(getUuidMetadataResult.Uuid, meta);
-                }
-            }
         }
 
         /// <summary>

--- a/Assets/SuperMultiplayerShooter/Scripts/UIManager.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/UIManager.cs
@@ -129,7 +129,7 @@ public class MyClass
             gameOverPanel.SetActive(false);
             hurtOverlay.color = Color.clear;
             //Initializes the PubNub Connection.
-            pubnub = PNManager.pubnubInstance;
+            pubnub = PNManager.pubnubInstance.InitializePubNub();
 
             // Show mobile controls if needed:
             mobileControlsPanel.SetActive(gm.useMobileControls);

--- a/Packages/com.pubnub.sdk/Runtime/Util/PNManagerBehaviour.cs
+++ b/Packages/com.pubnub.sdk/Runtime/Util/PNManagerBehaviour.cs
@@ -28,12 +28,16 @@ namespace PubnubApi.Unity {
 				Debug.LogError("PNConfigAsset is missing", this);
 				return null;
 			}
-			
+
+			/*
+			 * Commenting out due to having issues with using a singular PubNub instance in Unity SDK v7.
+			 * In cases where users are subscribing to different channels, leave and join events are generated
+			 * that is affecting functionality.
 			if (pubnub is not null) {
 				Debug.LogError("PubNub has already been initialized");
 				return pubnub;
 			}
-			
+			*/
 			pnConfiguration.UserId = userId;
 			pubnub = new Pubnub(pnConfiguration);
 			pubnub.AddListener(listener);


### PR DESCRIPTION
-In Unity SDK v6, the showcase game originally uses a different PubNub SDK across different scenes in Unity due to the architecture. -This was changed to use a singular SDK instance for v7, but it is causing severe problems due to some of the change/leave events being generated when making different subscribe calls, affecting functionality in the game. -Commented out some behavior in PNManagerBehavior.cs that was returning a singular PubNub instance if one existed which was interfering with these changes.