### PR TITLE
Fixed Translation and Cacheing Bugs

### DIFF
--- a/Assets/SuperMultiplayerShooter/Scripts/Connector.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/Connector.cs
@@ -183,7 +183,7 @@ namespace Visyde
                     PubNubUtilities.chanRoomStatus,
                     PubNubUtilities.chanChatAll,
                     PubNubUtilities.chanPrivateChat,
-                    PubNubUtilities.chanChatTranslate + "*",
+                    PubNubUtilities.chanChatTranslate + userId,
                     PubNubUtilities.chanLeaderboardSub,
                     PubNubUtilities.chanFriendRequest + userId
                 })

--- a/Assets/SuperMultiplayerShooter/Scripts/MessageModeration.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/MessageModeration.cs
@@ -7,5 +7,6 @@ public class MessageModeration
 	public string source;
 	public string target;
 	public string publisher;
+	public string chatType;
 }
 


### PR DESCRIPTION
-Fixed translation messages repeated multiple times for more than two players
-Ensuring when players come online, check cache. If they are not there, get their metadata.