### PR TITLE
Single pub nub instance

### DIFF
--- a/Assets/SuperMultiplayerShooter/Scripts/AIController.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/AIController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using UnityEngine;
 using PubNubUnityShowcase;
+using PubnubApi;
 
 namespace Visyde
 {
@@ -56,6 +57,7 @@ namespace Visyde
         int lastHp, doMoveDir;
         public int chosenEmote = -1;
         private BotSpawner bs;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         // Map bounds knowledge so we know where should we not go:
         float worldBoundXPos, worldBoundXNeg, worldBoundYPos, worldBoundYNeg;
@@ -766,7 +768,7 @@ namespace Visyde
             {
                 if (chosenEmote > 0)
                 {
-                    new PubNubUtilities().SendEmoji(GameManager.instance.pubnub, chosenEmote, botID);
+                    new PubNubUtilities().SendEmoji(pubnub, chosenEmote, botID);
                     chosenEmote = -1;
                 }
                 yield return new WaitForSecondsRealtime(Random.Range(1f, 6f));

--- a/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsList.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsList.cs
@@ -15,19 +15,20 @@ public class FriendsList : MonoBehaviour
     public FriendsListItem friendsListItemPrefab;         // the room item prefab (represents a game session in the lobby list)
     public Button searchFriendsButton;
     public GameObject privateMessagePopupPanel;
+    private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
     // Start is called before the first frame update
     async void Start()
     {
         //Listeners
         Connector.instance.OnPlayerSelect += AddFriend;
-        Connector.instance.onPubNubMessage += OnPnMessage;
-        Connector.instance.onPubNubPresence += OnPnPresence;
-        Connector.instance.onPubNubObject += OnPnObject;
+        PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
+        PNManager.pubnubInstance.onPubNubPresence += OnPnPresence;
+        PNManager.pubnubInstance.onPubNubObject += OnPnObject;
 
         // Since both online status and message channel groups are in conjunction, doesn't matter which to use.
         //Populate friend group
-        await PopulateFriendList(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId());
+        await PopulateFriendList(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId());
         // Get Online Status of Friends by referencing who's currently online.
         await GetCurrentFriendOnlineStatus();
     }
@@ -35,9 +36,9 @@ public class FriendsList : MonoBehaviour
     public void OnDestroy()
     {
         Connector.instance.OnPlayerSelect -= AddFriend;
-        Connector.instance.onPubNubMessage -= OnPnMessage;
-        Connector.instance.onPubNubPresence -= OnPnPresence;
-        Connector.instance.onPubNubObject -= OnPnObject;
+        PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
+        PNManager.pubnubInstance.onPubNubPresence -= OnPnPresence;
+        PNManager.pubnubInstance.onPubNubObject -= OnPnObject;
     }
 
     /// <summary>
@@ -50,7 +51,7 @@ public class FriendsList : MonoBehaviour
         if(result != null && !string.IsNullOrWhiteSpace(result.Message.ToString())
             && !string.IsNullOrWhiteSpace(result.Channel) && (result.Channel.StartsWith(PubNubUtilities.chanFriendRequest))
             && PNManager.pubnubInstance.CachedPlayers.ContainsKey(result.Publisher) 
-            && !PNManager.pubnubInstance.CachedPlayers[result.Publisher].Equals(Connector.instance.GetPubNubObject().GetCurrentUserId()))
+            && !PNManager.pubnubInstance.CachedPlayers[result.Publisher].Equals(pubnub.GetCurrentUserId()))
         {
             //Handle request based on the message.
             switch(result.Message)
@@ -114,7 +115,7 @@ public class FriendsList : MonoBehaviour
     private void OnPnPresence(PNPresenceEventResult result)
     {
         //Update to use channel group catching, rather than global
-        if(result != null && result.Subscription != null && result.Subscription.Equals(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId()))
+        if(result != null && result.Subscription != null && result.Subscription.Equals(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId()))
         {
             FriendsListItem friend = GetFriend(result.Uuid);
             if(friend != null)
@@ -187,12 +188,12 @@ public class FriendsList : MonoBehaviour
             friendItem.removeButton.name = "remove";
             //If a profile image or other metadata wants to be displayed for each player in the list, can update this function in the future.
             friendItem.Set(id, PNManager.pubnubInstance.CachedPlayers[id].Name);
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + id });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + id });
             // Add friend to status feed group
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + id });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + id });
             string message = "request"; //initiates a friend request.
             // Send Message to indicate request has been made.
-            PNResult<PNPublishResult> publishResponse = await Connector.instance.GetPubNubObject().Publish()
+            PNResult<PNPublishResult> publishResponse = await pubnub.Publish()
                .Channel(PubNubUtilities.chanFriendRequest + id) //chanFriendRequest channel reserved for handling friend requests.
                .Message(message)
                .ExecuteAsync();
@@ -213,7 +214,7 @@ public class FriendsList : MonoBehaviour
     /// <returns></returns>
     public async Task<bool> PopulateFriendList(string channelGroup)
     {    
-        PNResult<PNChannelGroupsAllChannelsResult> cgListChResponse = await Connector.instance.GetPubNubObject().ListChannelsForChannelGroup()
+        PNResult<PNChannelGroupsAllChannelsResult> cgListChResponse = await pubnub.ListChannelsForChannelGroup()
             .ChannelGroup(channelGroup)
             .ExecuteAsync();
 
@@ -230,7 +231,7 @@ public class FriendsList : MonoBehaviour
                 //UserIds are contained within the channel names.
                 string id = channel.Substring(PubNubUtilities.chanPresence.Length);
                 //Don't add self to the friend list.
-                if(!id.Equals(Connector.instance.GetPubNubObject().GetCurrentUserId()) && PNManager.pubnubInstance.CachedPlayers.ContainsKey(id))
+                if(!id.Equals(pubnub.GetCurrentUserId()) && PNManager.pubnubInstance.CachedPlayers.ContainsKey(id))
                 {
                     FriendsListItem friendItem = Instantiate(friendsListItemPrefab, friendsListItemHandler);
                     friendItem.name = id; // set the name to be able to access later for updates.
@@ -241,8 +242,8 @@ public class FriendsList : MonoBehaviour
 
             // Obtain history of messages from the friend request channel to determine if there are any pending invites.
             // Please Note that this will cap out on 100 friend requests.
-            PNResult<PNFetchHistoryResult> fetchHistoryResponse = await Connector.instance.GetPubNubObject().FetchHistory()
-                .Channels(new string[] { PubNubUtilities.chanFriendRequest + Connector.instance.GetPubNubObject().GetCurrentUserId() })
+            PNResult<PNFetchHistoryResult> fetchHistoryResponse = await pubnub.FetchHistory()
+                .Channels(new string[] { PubNubUtilities.chanFriendRequest + pubnub.GetCurrentUserId() })
                 .ExecuteAsync();
            if(fetchHistoryResponse != null && fetchHistoryResponse.Result != null && fetchHistoryResponse.Result.Messages != null && !fetchHistoryResponse.Status.Error)
             {
@@ -280,10 +281,10 @@ public class FriendsList : MonoBehaviour
         else
         {
             // remember, channels wont be added again to channel groups if they've already been done so.
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + Connector.instance.GetPubNubObject().GetCurrentUserId() });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + pubnub.GetCurrentUserId() });
 
             //Add self mpresene channel to status feed channel group
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + Connector.instance.GetPubNubObject().GetCurrentUserId() });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + pubnub.GetCurrentUserId() });
             return true;
         }
     }
@@ -294,7 +295,7 @@ public class FriendsList : MonoBehaviour
     /// <returns></returns>
     private async Task<bool> GetCurrentFriendOnlineStatus()
     {
-        PNResult<PNHereNowResult> herenowResponse = await Connector.instance.GetPubNubObject().HereNow()
+        PNResult<PNHereNowResult> herenowResponse = await pubnub.HereNow()
             .Channels(new string[]
             {
             PubNubUtilities.chanGlobal

--- a/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsList.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsList.cs
@@ -193,12 +193,12 @@ public class FriendsList : MonoBehaviour
                 friendItem.removeButton.name = "remove";
                 //If a profile image or other metadata wants to be displayed for each player in the list, can update this function in the future.
                 friendItem.Set(id, PNManager.pubnubInstance.CachedPlayers[id].Name);
-                await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + id });
+                await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + id });
                 // Add friend to status feed group
-                await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + id });
+                await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + id });
                 string message = "request"; //initiates a friend request.
                                             // Send Message to indicate request has been made.
-                PNResult<PNPublishResult> publishResponse = await Connector.instance.GetPubNubObject().Publish()
+                PNResult<PNPublishResult> publishResponse = await pubnub.Publish()
                    .Channel(PubNubUtilities.chanFriendRequest + id) //chanFriendRequest channel reserved for handling friend requests.
                    .Message(message)
                    .ExecuteAsync();

--- a/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsListItem.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/FriendsList/FriendsListItem.cs
@@ -15,6 +15,7 @@ namespace Visyde
         public Button tradeButton;
         public Button acceptButton;
         public Button removeButton;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         private string userId;
 
@@ -59,14 +60,14 @@ namespace Visyde
             //remove = added to friend group, reject = yet to add friend to friend group.
             if(removeButton.name.Equals("remove"))
             {
-                await PNManager.pubnubInstance.RemoveChannelsFromChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + userId });
-                await PNManager.pubnubInstance.RemoveChannelsFromChannelGroup(PubNubUtilities.chanFriendChanGroupChat + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + userId });
+                await PNManager.pubnubInstance.RemoveChannelsFromChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + userId });
+                await PNManager.pubnubInstance.RemoveChannelsFromChannelGroup(PubNubUtilities.chanFriendChanGroupChat + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + userId });
             }
 
             //Send reject request.
             string message = "reject";
             // Send Message to indicate request has been made.
-            PNResult<PNPublishResult> publishResponse = await Connector.instance.GetPubNubObject().Publish()
+            PNResult<PNPublishResult> publishResponse = await pubnub.Publish()
                .Channel(PubNubUtilities.chanFriendRequest + userId) //chanFriendRequest channel reserved for handling friend requests.
                .Message(message)
                .ExecuteAsync();
@@ -86,13 +87,13 @@ namespace Visyde
             gameObject.GetComponent<Image>().color = Color.white; // change color to show accepted friend.
 
             //Add to channel group.
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + userId });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupStatus + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanPresence + userId });
             // Add friend to status feed group
-            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + Connector.instance.GetPubNubObject().GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + userId });
+            await PNManager.pubnubInstance.AddChannelsToChannelGroup(PubNubUtilities.chanFriendChanGroupChat + pubnub.GetCurrentUserId(), new string[] { PubNubUtilities.chanFriendChat + userId });
 
             string message = "accept"; // message will be one of four things: request, accept, reject, remove
             // Send Message to indicate request has been made.
-            PNResult<PNPublishResult> publishResponse = await Connector.instance.GetPubNubObject().Publish()
+            PNResult<PNPublishResult> publishResponse = await pubnub.Publish()
                .Channel(PubNubUtilities.chanFriendRequest + userId) //chanFriendRequest channel reserved for handling friend requests.
                .Message(message)
                .ExecuteAsync();

--- a/Assets/SuperMultiplayerShooter/Scripts/GameManager.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/GameManager.cs
@@ -20,7 +20,7 @@ namespace Visyde
         public static GameManager instance;
 
         //  PubNub Properties
-        public Pubnub pubnub = null;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
         private PubNubUtilities pubNubUtilities = new PubNubUtilities();
         private SubscribeCallbackListener listener = new SubscribeCallbackListener();
         public readonly Dictionary<string, GameObject> ResourceCache = new Dictionary<string, GameObject>();
@@ -133,7 +133,6 @@ namespace Visyde
         void Awake()
         {
             instance = this;
-            pubnub = Connector.instance.GetPubNubObject();
 
             // Prepare player instance arrays:
             bots = new PlayerInstance[0];
@@ -182,8 +181,8 @@ namespace Visyde
                     channels.Add(PubNubUtilities.ToGameChannel(PubNubUtilities.chanPrefixPlayerCursor + bot.playerID));
                 }
             }
-            Connector.instance.onPubNubMessage += OnPnMessage;
-            Connector.instance.onPubNubPresence += OnPnPresence;
+            PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
+            PNManager.pubnubInstance.onPubNubPresence += OnPnPresence;
             //Subscribe to the list of Channels
             pubnub.Subscribe<string>()
                .Channels(channels)
@@ -220,8 +219,8 @@ namespace Visyde
         void OnDestroy()
         {
             //  Unsubscribe only for this PubNub instance (which is unique per game)
-            Connector.instance.onPubNubMessage -= OnPnMessage;
-            Connector.instance.onPubNubPresence -= OnPnPresence;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubPresence -= OnPnPresence;
             pubnub.Unsubscribe<string>().Channels(channels.ToArray()).Execute();
         }
 
@@ -786,7 +785,6 @@ namespace Visyde
                     if (payload.ContainsKey("started"))
                     {
                         gameStarted = (bool)payload["started"];
-                        Invoke("AddPresenceListener", 1.0f);
                     }
                     if (payload.ContainsKey("gameStartsIn"))
                     {
@@ -893,11 +891,6 @@ namespace Visyde
                     }
                 }
             }
-        }
-
-        private void AddPresenceListener()
-        {
-            Connector.instance.AddPresenceListener();
         }
 
         //  PubNub Presence event handler

--- a/Assets/SuperMultiplayerShooter/Scripts/ItemSpawner.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/ItemSpawner.cs
@@ -32,6 +32,8 @@ namespace Visyde
         [HideInInspector] public Transform[] currentPowerUpSpawns;                      // used for checking if a certain spawn point still has a power-up pickup
 
         private PubNubUtilities pubNubUtilities;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
+
 
         void Start()
         {
@@ -45,7 +47,7 @@ namespace Visyde
             pubNubUtilities = new PubNubUtilities();
 
             //Add Listeners
-            Connector.instance.onPubNubMessage += OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
         }
 
         // Update is called once per frame
@@ -80,7 +82,7 @@ namespace Visyde
         /// </summary>
         private void OnDestroy()
         {
-            Connector.instance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
         }
 
         /// <summary>
@@ -135,7 +137,7 @@ namespace Visyde
         {
             GameMap map = gm.maps[gm.chosenMap];
             int weaponIndex = Random.Range(0, map.spawnableWeapons.Length);
-            pubNubUtilities.SpawnWeapon(gm.pubnub, i, weaponIndex);
+            pubNubUtilities.SpawnWeapon(pubnub, i, weaponIndex);
         }
 
         void SpawnWeapon(int index, int spawnId)
@@ -162,7 +164,7 @@ namespace Visyde
         {
             GameMap map = gm.maps[gm.chosenMap];
             int powerUpIndex = Random.Range(0, map.spawnablePowerUps.Length);
-            pubNubUtilities.SpawnPowerUp(gm.pubnub, i, powerUpIndex);
+            pubNubUtilities.SpawnPowerUp(pubnub, i, powerUpIndex);
         }
 
         void SpawnPowerUp(int index, int spawnId)

--- a/Assets/SuperMultiplayerShooter/Scripts/Leaderboard.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/Leaderboard.cs
@@ -23,11 +23,12 @@ public class Leaderboard : MonoBehaviour
     public Text kdPos3;
     public Text kdPos4;
     public Text kdPos5;
+    private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
     // Start is called before the first frame update
     void Start()
     {
-        Connector.instance.onPubNubMessage += OnPnMessage;
+        PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
         Connector.instance.OnConnectorReady += ConnectorReady;       
     }
 
@@ -36,7 +37,7 @@ public class Leaderboard : MonoBehaviour
     /// </summary>
     void OnDestroy()
     {
-        Connector.instance.onPubNubMessage -= OnPnMessage;
+        PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
     }
 
     /// <summary>
@@ -54,7 +55,7 @@ public class Leaderboard : MonoBehaviour
     /// <param name="text"></param>
     private async Task<bool> PublishMessage(string text, string channel)
     {
-        PNResult<PNPublishResult> publishResponse = await Connector.instance.GetPubNubObject().Publish()
+        PNResult<PNPublishResult> publishResponse = await pubnub.Publish()
          .Channel(channel)
          .Message(text)
          .ExecuteAsync();

--- a/Assets/SuperMultiplayerShooter/Scripts/Leaderboard.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/Leaderboard.cs
@@ -29,7 +29,7 @@ public class Leaderboard : MonoBehaviour
     void Start()
     {
         PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
-        Connector.instance.OnConnectorReady += ConnectorReady;       
+        PNManager.pubnubInstance.onPubNubReady += OnPnReady;
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class Leaderboard : MonoBehaviour
     /// <summary>
     /// Waits until the connector is ready before attempting to publish using pubnub object.
     /// </summary>
-    private async void ConnectorReady()
+    private async void OnPnReady()
     {
         //fire a refresh command to the pubnub function to get the leaderboard to update
         await PublishMessage("{\"username\":\"\",\"score\":\"\",\"refresh\":\"true\"}", PubNubUtilities.chanLeaderboardPub);

--- a/Assets/SuperMultiplayerShooter/Scripts/MeleeWeaponController.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/MeleeWeaponController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using PubNubUnityShowcase;
+using PubnubApi;
 
 namespace Visyde
 {
@@ -24,6 +25,7 @@ namespace Visyde
         [HideInInspector] public bool isAttacking;
         PlayerController ourPlayer;
         PubNubUtilities pubNubUtilities = new PubNubUtilities();
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         // Update is called once per frame
         void Update()
@@ -53,7 +55,7 @@ namespace Visyde
                             // Don't hurt self and the invulnerable:
                             if (p.playerInstance != ourPlayer.playerInstance && !p.invulnerable)
                             {
-                                pubNubUtilities.ApplyDamage(GameManager.instance.pubnub, p.playerInstance.playerID, ourPlayer.playerInstance.playerID, damage, false);
+                                pubNubUtilities.ApplyDamage(pubnub, p.playerInstance.playerID, ourPlayer.playerInstance.playerID, damage, false);
 
                                 // VFX
                                 GameManager.instance.pooler.Spawn("BodyHit", p.transform.position);

--- a/Assets/SuperMultiplayerShooter/Scripts/PNRoomInfo.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PNRoomInfo.cs
@@ -11,7 +11,7 @@ namespace PubNubUnityShowcase
     public class PNRoomInfo
     {
         public static int MAX_BOTS = 4; //  Done for simplicity
-        public PNRoomInfo(string ownerId, string name, int map, int maxPlayers, bool allowBots, long id)
+        public PNRoomInfo(string ownerId, string name, int map, int maxPlayers, bool allowBots, long id, int gameLength)
         {
             OwnerId = ownerId;  //  The PubNub ID of the user who created the game
             Name = name;        //  Typically the same as the nickname of the user who created the game
@@ -21,7 +21,9 @@ namespace PubNubUnityShowcase
             this.PlayerList = new List<PNPlayer>();
             ID = id;
             IsOpen = true;
+            GameLength = gameLength;
         }
+        public int GameLength;
         //  Bots and bot objects define the same thing, keps separate for legacy reasons
         public Dictionary<string, object> Bots = null;  
         public Connector.Bot[] BotObjects = null;

--- a/Assets/SuperMultiplayerShooter/Scripts/PNRoomInfo.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PNRoomInfo.cs
@@ -23,7 +23,7 @@ namespace PubNubUnityShowcase
             IsOpen = true;
             GameLength = gameLength;
         }
-        public int GameLength;
+        public int GameLength { get; }
         //  Bots and bot objects define the same thing, keps separate for legacy reasons
         public Dictionary<string, object> Bots = null;  
         public Connector.Bot[] BotObjects = null;

--- a/Assets/SuperMultiplayerShooter/Scripts/PlayerController.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PlayerController.cs
@@ -16,6 +16,7 @@ namespace Visyde
     {
         //  PubNub variables
         private PubNubUtilities pubNubUtilities;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         public PubNubPlayerProps pubNubPlayerProps { get; set; }
         private bool initialPosition = true;
@@ -144,8 +145,8 @@ namespace Visyde
 
             pubNubUtilities = new PubNubUtilities();
             //Add Listeners
-            Connector.instance.onPubNubMessage += OnPnMessage;
-            Connector.instance.onPubNubSignal += OnPnSignal;
+            PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
+            PNManager.pubnubInstance.onPubNubSignal += OnPnSignal;
 
             if (gm.players.Length + gm.bots.Length <= 3)
             {
@@ -495,7 +496,7 @@ namespace Visyde
                     {
                         if (t.position.y < gm.deadZoneOffset && !doneDeadZone)
                         {
-                            pubNubUtilities.TriggerDeadZone(gm.pubnub, playerInstance.playerID, movementController.position);
+                            pubNubUtilities.TriggerDeadZone(pubnub, playerInstance.playerID, movementController.position);
                             TriggerDeadZone(movementController.position);
                             doneDeadZone = true;
                         }
@@ -583,7 +584,7 @@ namespace Visyde
                 // Update the others about our status:
                 if (pubNubPlayerProps.IsMine)
                 {
-                    pubNubUtilities.UpdateOthersPlayerStatus(gm.pubnub, playerInstance.playerID, health, shield);
+                    pubNubUtilities.UpdateOthersPlayerStatus(pubnub, playerInstance.playerID, health, shield);
                     
                     // If this is local player's, let the game manager know this is ours and is now dead:
                     if (isPlayerOurs && !gm.isGameOver) gm.dead = true;
@@ -632,17 +633,17 @@ namespace Visyde
                 //  so you may have to implement a more robust emote input system depending on your project's needs):
                 if (Input.GetKeyDown(KeyCode.Alpha1))
                 {
-                    pubNubUtilities.SendEmoji(gm.pubnub, 0, playerInstance.playerID);
+                    pubNubUtilities.SendEmoji(pubnub, 0, playerInstance.playerID);
                     Emote(0);
                 }
                 if (Input.GetKeyDown(KeyCode.Alpha2))
                 {
-                    pubNubUtilities.SendEmoji(gm.pubnub, 1, playerInstance.playerID);
+                    pubNubUtilities.SendEmoji(pubnub, 1, playerInstance.playerID);
                     Emote(1);
                 }
                 if (Input.GetKeyDown(KeyCode.Alpha3))
                 {
-                    pubNubUtilities.SendEmoji(gm.pubnub, 2, playerInstance.playerID);
+                    pubNubUtilities.SendEmoji(pubnub, 2, playerInstance.playerID);
                     Emote(2);
                 }
 
@@ -803,7 +804,7 @@ namespace Visyde
 
         public void OwnerShootCommand(){
             Shoot(mousePos, movementController.position, movementController.velocity);
-            pubNubUtilities.Shoot(gm.pubnub, playerInstance.playerID, mousePos);
+            pubNubUtilities.Shoot(pubnub, playerInstance.playerID, mousePos);
         }
         // Called by the owner from mobile or pc input:
         public void OwnerMeleeAttack()
@@ -811,7 +812,7 @@ namespace Visyde
             if (curMeleeAttackRate >= 1)
             {
                 MeleeAttack();
-                pubNubUtilities.MeleeAttack(gm.pubnub, playerInstance.playerID);
+                pubNubUtilities.MeleeAttack(pubnub, playerInstance.playerID);
                 curMeleeAttackRate = 0;
             }
         }
@@ -826,7 +827,7 @@ namespace Visyde
 
         void Die()
         {
-            pubNubUtilities.ForceDead(gm.pubnub, playerInstance.playerID);
+            pubNubUtilities.ForceDead(pubnub, playerInstance.playerID);
             if (!gm.isGameOver)
             {
                 // Multikill (if we are the killer and we are not the one dying):
@@ -857,8 +858,8 @@ namespace Visyde
                 catch (System.Exception) { }
 
                 // and then destroy (give a time for the death animation):
-                Connector.instance.onPubNubMessage -= OnPnMessage;
-                Connector.instance.onPubNubSignal -= OnPnSignal;
+                PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
+                PNManager.pubnubInstance.onPubNubSignal -= OnPnSignal;
                 Invoke("PlayerDestroy", 1f);
             }
 
@@ -874,8 +875,8 @@ namespace Visyde
             invulnerabilityIndicator.SetActive(false);
 
             // PubNub
-            Connector.instance.onPubNubMessage -= OnPnMessage;
-            Connector.instance.onPubNubSignal -= OnPnSignal;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubSignal -= OnPnSignal;
         }
 
         public void Teleport(Vector3 newPos)
@@ -910,7 +911,7 @@ namespace Visyde
         /// <param name="value">Can be either a weapon id (if a gun was used) or a damage value (if melee attack or grenade).</param>
         /// <param name="gun">If set to <c>true</c>, "value" will be used as weapon id.</param>
         public void ApplyDamage(int fromPlayer, int value, bool gun){
-            pubNubUtilities.ApplyDamage(gm.pubnub, playerInstance.playerID, fromPlayer, value, gun);
+            pubNubUtilities.ApplyDamage(pubnub, playerInstance.playerID, fromPlayer, value, gun);
         }
 
         void Hurt(int fromPlayer, int value, bool gun)
@@ -1048,7 +1049,7 @@ namespace Visyde
             if (curWeapon && thePowerUp.fullRefillAmmo) curWeapon.curAmmo = curWeapon.ammo;
 
             // Update others about our current vital stats (health and shield):
-            pubNubUtilities.UpdateOthersPlayerStatus(gm.pubnub, playerInstance.playerID, health, shield);
+            pubNubUtilities.UpdateOthersPlayerStatus(pubnub, playerInstance.playerID, health, shield);
         }
 
         public void Emote(int emote){
@@ -1075,8 +1076,8 @@ namespace Visyde
         void OnDestroy()
         {
             if (forPreview) return;
-            Connector.instance.onPubNubMessage -= OnPnMessage;
-            Connector.instance.onPubNubSignal -= OnPnSignal;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubSignal -= OnPnSignal;
             OnDisable();
             Destroy(cosmeticsManager);
         }
@@ -1112,7 +1113,7 @@ namespace Visyde
 
             if (playerInstance.IsMine || (Connector.instance.isMasterClient && playerInstance.IsBot))
             {
-                pubNubUtilities.UpdatePlayerPosition(gm.pubnub, playerInstance.playerID,
+                pubNubUtilities.UpdatePlayerPosition(pubnub, playerInstance.playerID,
                 movementController.position, movementController.velocity);
             }
         }
@@ -1122,7 +1123,7 @@ namespace Visyde
             if (forPreview) return;
             if (playerInstance.IsMine || (Connector.instance.isMasterClient && playerInstance.IsBot))
             {
-                    pubNubUtilities.UpdatePlayerCursor(gm.pubnub, playerInstance.playerID,
+                    pubNubUtilities.UpdatePlayerCursor(pubnub, playerInstance.playerID,
                     mousePos, moving, isFalling, xInput);
             }
         }

--- a/Assets/SuperMultiplayerShooter/Scripts/PlayerInstance.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PlayerInstance.cs
@@ -88,6 +88,7 @@ namespace Visyde
                 Dictionary<string, object> playerProps = new Dictionary<string, object>();
                 playerProps.Add("playerStats", "stats");
                 playerProps.Add("playerId", playerID);
+                playerProps.Add("roomOwnerId", Connector.instance.CurrentRoom.OwnerId);
                 if (Kills != 0) playerProps.Add("kills", Kills);
                 if (Deaths != 0) playerProps.Add("deaths", Deaths);
                 if (OtherScore != 0) playerProps.Add("otherScore", OtherScore);

--- a/Assets/SuperMultiplayerShooter/Scripts/PlayerInstance.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PlayerInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using PubnubApi;
 using PubNubUnityShowcase;
 
 namespace Visyde
@@ -17,6 +18,7 @@ namespace Visyde
         public string PlayerName { get; }
         public int Character { get; }
         public PNPlayer player { get; protected set; }
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         // Cosmetics:
         public Cosmetics cosmeticItems;
@@ -89,7 +91,7 @@ namespace Visyde
                 if (Kills != 0) playerProps.Add("kills", Kills);
                 if (Deaths != 0) playerProps.Add("deaths", Deaths);
                 if (OtherScore != 0) playerProps.Add("otherScore", OtherScore);
-                new PubNubUtilities().PubNubSendRoomProperties(GameManager.instance.pubnub, playerProps);
+                new PubNubUtilities().PubNubSendRoomProperties(pubnub, playerProps);
             }
         }
     }

--- a/Assets/SuperMultiplayerShooter/Scripts/PowerUpPickup.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PowerUpPickup.cs
@@ -28,6 +28,7 @@ namespace Visyde
         int index;
 
         PubNubUtilities pubNubUtilities;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         // Use this for initialization
         void Start()
@@ -39,7 +40,7 @@ namespace Visyde
             PubNubItemProps initProps = GetComponent<PubNubItemProps>();
 
             //Listeners
-            Connector.instance.onPubNubMessage += OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
 
             if (initProps)
             {
@@ -76,7 +77,7 @@ namespace Visyde
         /// </summary>
         private void OnDestroy()
         {
-            Connector.instance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
         }
 
         void Allow()
@@ -105,8 +106,8 @@ namespace Visyde
                         // Only the master client will handle the power-up actions:
                         if (PubNubUtilities.IsMasterClient)
                         {
-                            pubNubUtilities.ReceivePowerUp(gm.pubnub, p.playerInstance.playerID, powerUpIndex, spawnPointIndex);
-                            pubNubUtilities.PickedUpPowerUp(gm.pubnub, index);
+                            pubNubUtilities.ReceivePowerUp(pubnub, p.playerInstance.playerID, powerUpIndex, spawnPointIndex);
+                            pubNubUtilities.PickedUpPowerUp(pubnub, index);
                         }
                     }
                 }

--- a/Assets/SuperMultiplayerShooter/Scripts/PubNubUtilities.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/PubNubUtilities.cs
@@ -3,6 +3,7 @@ using PubnubApi;
 using PubnubApi.Unity;
 using System.Collections.Generic;
 using Visyde;
+using System.Threading.Tasks;
 
 /// <summary>
 /// PubNubUtilities
@@ -417,7 +418,7 @@ namespace PubNubUnityShowcase
             return instance;
         }
 
-        public async void PubNubSendRoomProperties(Pubnub pubnub, Dictionary<string, object> payload)
+        public async Task PubNubSendRoomProperties(Pubnub pubnub, Dictionary<string, object> payload)
         {
             await pubnub.Publish()
                 .Channel(PubNubUtilities.chanRoomStatus)
@@ -425,11 +426,11 @@ namespace PubNubUnityShowcase
                 .ExecuteAsync();
         }
 
-        public void PubNubSendRoomProperties(Pubnub pubnub, string property, object value)
+        public async Task PubNubSendRoomProperties(Pubnub pubnub, string property, object value)
         {
             Dictionary<string, object> payload = new Dictionary<string, object>();
             payload[property] = value;
-            PubNubSendRoomProperties(pubnub, payload);
+            await PubNubSendRoomProperties(pubnub, payload);
         }
 
         public static string GetCurrentMethodName()

--- a/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using UnityEngine.Localization.Settings;
 using UnityEngine.Localization;
 using PubNubUnityShowcase;
+using System.Runtime.ConstrainedExecution;
 
 namespace Visyde
 {
@@ -55,9 +56,8 @@ namespace Visyde
 
         async void OnPnReady()
         {
-            await GetActiveGlobalPlayers();
+            Invoke("GetActiveGlobalPlayers", 2.0f); //  Give the system time to settle down before calling global player count
             await PNManager.pubnubInstance.GetAllUserMetadata(); //Loading Player Cache.
-
             customMatchBTN.interactable = true;
             customizeCharacterButton.interactable = true;
             //  todo set friends button interactable

--- a/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/SampleMainMenu.cs
@@ -37,19 +37,21 @@ namespace Visyde
         public GameObject lobbyBrowserPanel;
         public GameObject settingsPanel;
         public GameObject cosmeticsPanel;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         void Awake(){
             Screen.sleepTimeout = SleepTimeout.SystemSetting;
         }
 
         // Use this for initialization
-        void Start()
+        async void Start()
         {
             //Add Listeners
+            await PNManager.pubnubInstance.InitializePubNub();
             Connector.instance.OnGlobalPlayerCountUpdate += UpdateGlobalPlayers;
             Connector.instance.OnConnectorReady += ConnectorReady;
-            Connector.instance.onPubNubPresence += OnPnPresence;
-            Connector.instance.onPubNubObject += OnPnObject;
+            PNManager.pubnubInstance.onPubNubPresence += OnPnPresence;
+            PNManager.pubnubInstance.onPubNubObject += OnPnObject;
         }
 
         /// <summary>
@@ -176,8 +178,8 @@ namespace Visyde
         {
             Connector.instance.OnGlobalPlayerCountUpdate -= UpdateGlobalPlayers;
             Connector.instance.OnConnectorReady -= ConnectorReady;
-            Connector.instance.onPubNubPresence -= OnPnPresence;
-            Connector.instance.onPubNubObject -= OnPnObject;
+            PNManager.pubnubInstance.onPubNubPresence -= OnPnPresence;
+            PNManager.pubnubInstance.onPubNubObject -= OnPnObject;
 
             //Clear out the cached players when changing scenes. The list needs to be updated when returning to the scene in case
             //there are new players.
@@ -190,11 +192,11 @@ namespace Visyde
         private void MainMenuSetup()
         {          
             //Change playerInput name to be set to username of the user as long as the name was originally set.
-            if (PNManager.pubnubInstance.CachedPlayers.Count > 0 && PNManager.pubnubInstance.CachedPlayers.ContainsKey(Connector.instance.GetPubNubObject().GetCurrentUserId()))
+            if (PNManager.pubnubInstance.CachedPlayers.Count > 0 && PNManager.pubnubInstance.CachedPlayers.ContainsKey(pubnub.GetCurrentUserId()))
             {
-                playerNameInput.text = Connector.PNNickName = PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Name;
+                playerNameInput.text = Connector.PNNickName = PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name;
                 //  Populate the available hat inventory and other settings, read from PubNub App Context
-                Dictionary<string, object> customData = PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Custom;
+                Dictionary<string, object> customData = PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Custom;
                 if (customData != null)
                 {
                     List<int> availableHats = new List<int>();
@@ -208,7 +210,7 @@ namespace Visyde
                     {
                         availableHats = Connector.instance.GenerateRandomHats();
                         customData.Add("hats", availableHats);
-                        PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Custom = customData;
+                        PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Custom = customData;
                     }
 
                     Connector.instance.UpdateAvailableHats(availableHats);
@@ -231,8 +233,8 @@ namespace Visyde
         // Changes the player name whenever the user edits the Nickname input (on enter or click out of input field)
         public async void SetPlayerName()
         {
-            await PNManager.pubnubInstance.UpdateUserMetadata(Connector.instance.GetPubNubObject().GetCurrentUserId(), playerNameInput.text, PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Custom);
-            Connector.PNNickName = PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Name = playerNameInput.text;     
+            await PNManager.pubnubInstance.UpdateUserMetadata(pubnub.GetCurrentUserId(), playerNameInput.text, PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Custom);
+            Connector.PNNickName = PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name = playerNameInput.text;     
         }
     }
 }

--- a/Assets/SuperMultiplayerShooter/Scripts/SettingsWindow.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/SettingsWindow.cs
@@ -22,7 +22,8 @@ public class SettingsWindow : MonoBehaviour
     //internals
     private int originalLanguageLocation;
     private bool fpsToggled;
-    
+    private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
+
 
     // Start is called before the first frame update
     void Start()
@@ -87,10 +88,10 @@ public class SettingsWindow : MonoBehaviour
         if(changesMade)
         {           
             //If successful, update the Connector object.
-            if (PNManager.pubnubInstance.CachedPlayers.ContainsKey(Connector.instance.GetPubNubObject().GetCurrentUserId())
-                && PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Custom != null)
+            if (PNManager.pubnubInstance.CachedPlayers.ContainsKey(pubnub.GetCurrentUserId())
+                && PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Custom != null)
             {
-                Dictionary<string, object> customData = PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Custom;
+                Dictionary<string, object> customData = PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Custom;
                 if(customData.ContainsKey("language"))
                 {
                     customData["language"] = LocalizationSettings.AvailableLocales.Locales[originalLanguageLocation].Identifier.Code;
@@ -111,7 +112,7 @@ public class SettingsWindow : MonoBehaviour
                     customData.Add("60fps", fpsToggled);
                 }
                 
-                await PNManager.pubnubInstance.UpdateUserMetadata(Connector.instance.GetPubNubObject().GetCurrentUserId(), PNManager.pubnubInstance.CachedPlayers[Connector.instance.GetPubNubObject().GetCurrentUserId()].Name, customData);
+                await PNManager.pubnubInstance.UpdateUserMetadata(pubnub.GetCurrentUserId(), PNManager.pubnubInstance.CachedPlayers[pubnub.GetCurrentUserId()].Name, customData);
             }
             
         }

--- a/Assets/SuperMultiplayerShooter/Scripts/UIManager.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/UIManager.cs
@@ -102,7 +102,6 @@ public class MyClass
 
         public bool isMenuShown { get { return menuPanel.activeSelf; }}
 
-        private Pubnub pubnub;
         private string _leaderboardChannelPub = "score.leaderboard";
         public bool notPublished = true; 
 
@@ -124,8 +123,6 @@ public class MyClass
             UpdateBoards();
             gameOverPanel.SetActive(false);
             hurtOverlay.color = Color.clear;
-            //Initializes the PubNub Connection.
-            pubnub = PNManager.pubnubInstance.InitializePubNub();
 
             // Show mobile controls if needed:
             mobileControlsPanel.SetActive(gm.useMobileControls);
@@ -494,7 +491,7 @@ public class MyClass
         /// <param name="text"></param>
         private async void PublishMessage(string text, string channel)
         {
-            await pubnub.Publish()
+            await PNManager.pubnubInstance.pubnub.Publish()
              .Channel(channel)
              .Message(text)
              .ExecuteAsync();

--- a/Assets/SuperMultiplayerShooter/Scripts/WeaponPickup.cs
+++ b/Assets/SuperMultiplayerShooter/Scripts/WeaponPickup.cs
@@ -26,6 +26,7 @@ namespace Visyde
         int index;
 
         PubNubUtilities pubNubUtilities;
+        private Pubnub pubnub { get { return PNManager.pubnubInstance.pubnub; } }
 
         // Use this for initialization
         void Start()
@@ -37,7 +38,7 @@ namespace Visyde
             PubNubItemProps initProps = GetComponent<PubNubItemProps>();
 
             //Listeners
-            Connector.instance.onPubNubMessage += OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage += OnPnMessage;
 
             if (initProps)
             {
@@ -70,7 +71,7 @@ namespace Visyde
         /// </summary>
         private void OnDestroy()
         {
-            Connector.instance.onPubNubMessage -= OnPnMessage;
+            PNManager.pubnubInstance.onPubNubMessage -= OnPnMessage;
         }
 
         void Allow()
@@ -94,8 +95,8 @@ namespace Visyde
 
                         if (PubNubUtilities.IsMasterClient)
                         {
-                            pubNubUtilities.GrabWeapon(gm.pubnub, p.playerInstance.playerID, weaponIndex, spawnPointIndex);
-                            pubNubUtilities.PickedUpWeapon(gm.pubnub, index);
+                            pubNubUtilities.GrabWeapon(pubnub, p.playerInstance.playerID, weaponIndex, spawnPointIndex);
+                            pubNubUtilities.PickedUpWeapon(pubnub, index);
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Note:
 This game is a work in progress, please bear with us whilst we make it awesome.  Any issues are a result of our implementation, not a limitation of PubNub :) 
 
 - Player trading has not been implemented.  The 'trade' button in the friend list will not do anything.
-- You can only have one game running at a time on the same keyset.  Trying to start a second _simultaneous_ game will confuse both games.
-- Players joining a lobby will occasionally not register with that lobby's creator.  If the creator does not see you appear in their room, the creator needs to close their lobby and start a new one.
-- Updating a characters name may not reflect for other players until they close and re-open the app.  This issue is intermittent.
-- The global presence count may be inaccurate when you first start the application.  A far rarer presence issue, likely related to this, is you may experience random disconnects during a game.
-- The game forcably tears down and recreates the connection with PubNub when a game is launched.  Sometimes this can prevent the game from starting or cause an expected disconnect.
 - Playing the game with players located on different continents can lead to unexpected results, such as characters not respawning.
 
 ## Prerequisites


### PR DESCRIPTION
Fixes a number of issues:
- There is only now one single PubNub instance used by all scenes and objects in the game.  Previously there were separate PubNub objects for the Connector and Game Menu which were being destroyed and recreated.  Moving to a single instance has increased the reliability of the application on match start, we see far fewer disconnects, 'waiting for players to start' and general instability.  Object events also appear to now be reliability received. This has not completely resolved all instability issues on match start, in extensive testing, I do still see occasional issues that require a restart of the game.
- Additional improvements to reliability such as ignoring room change requests whilst the match is starting and eliminating unsubscribing / resubscribing to channels that are common for all matches.
- The expected game duration is now sent to all clients when the match is started (part of the PNRoomInfo objects and currently hardcoded in Connector.cs)
- Bug fix to the lobby logic, where previously sometimes a user would try to join but it would not be registered by the master
- Can now run two simultaneous, independent games on the same keyset (so, for example, if you had two laptops set up with the same key, you could run two 1 player games at the same time)

**Notes:**
There are a lot of warnings about 'this is an async method but you don't await it'.  The game appears to start OK but these warnings probably need investigating.  